### PR TITLE
fix: wrangler pages deploy引数エラー修正 - compatibility-dateオプション除去

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -161,8 +161,20 @@ jobs:
       - name: 📦 Install Wrangler
         run: pnpm add -g wrangler
 
+      - name: 🔍 Verify Pages Project
+        run: |
+          if ! wrangler pages project list | grep -q "cloudflare-todo-sample-frontend"; then
+            echo "Creating Pages project..."
+            wrangler pages project create cloudflare-todo-sample-frontend
+          else
+            echo "Pages project already exists"
+          fi
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: 🚀 Deploy to Cloudflare Pages
-        run: wrangler pages deploy dist --project-name=cloudflare-todo-sample-frontend --compatibility-date=2025-01-20
+        run: wrangler pages deploy dist --project-name=cloudflare-todo-sample-frontend
         working-directory: packages/frontend
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## 概要

wrangler pages deploy の引数エラーを修正

Fixes #16

## 問題詳細

Deploy Frontendで以下エラーが発生:

```
✘ [ERROR] Unknown arguments: compatibility-date, compatibilityDate
```

**根本原因**: `wrangler pages deploy` は `--compatibility-date` オプションをサポートしていない

## 修正方針

1. **compatibility-dateオプション除去** → Pages deployでは不要
2. **プロジェクト存在確認** → 事前確認ステップ追加  
3. **コマンド簡略化** → 必要最小限のオプションのみ

## 実装予定

- [ ] `.github/workflows/deploy.yml` 修正
  - [ ] Frontend deploy: `--compatibility-date` オプション除去
  - [ ] Pages プロジェクト存在確認ステップ追加
  - [ ] エラーハンドリング改善
- [ ] デプロイテスト実行・確認

## 修正内容

### Before（エラー）
```bash
wrangler pages deploy dist --project-name=cloudflare-todo-sample-frontend --compatibility-date=2025-01-20
```

### After（修正）
```bash
wrangler pages deploy dist --project-name=cloudflare-todo-sample-frontend  
```

## 期待結果

✅ `wrangler pages deploy` コマンド成功
✅ Frontend build・deploy完了
✅ https://cloudflare-todo-sample-frontend.pages.dev 公開

## チェックリスト

- [x] Issue作成 (#16)
- [x] ブランチ作成・空コミット  
- [x] プルリクエスト作成
- [ ] deploy.yml修正実装
- [ ] テスト・動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)