### PR TITLE
fix: バックエンドデプロイ修正とAPI_BASE_URL設定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,7 +115,7 @@ jobs:
         run: pnpm add -g wrangler
 
       - name: 🚀 Deploy to Cloudflare Workers
-        run: wrangler deploy --env ${{ inputs.environment || 'production' }}
+        run: wrangler deploy --env production
         working-directory: packages/backend
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -125,7 +125,7 @@ jobs:
   deploy-frontend:
     name: 🌐 Deploy Frontend (Pages)
     runs-on: ubuntu-latest
-    needs: [pre-deploy, build-shared]
+    needs: [pre-deploy, build-shared, deploy-backend]
     if: needs.pre-deploy.outputs.should-deploy == 'true'
     environment: ${{ inputs.environment || 'production' }}
     
@@ -157,6 +157,7 @@ jobs:
         run: pnpm --filter=@cloudflare-todo-sample/frontend build
         env:
           NODE_ENV: production
+          VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
           VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
           VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
           VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}

--- a/packages/backend/wrangler.jsonc
+++ b/packages/backend/wrangler.jsonc
@@ -57,6 +57,20 @@
 	 */
 
 	/**
+	 * Environment-specific configurations
+	 */
+	"env": {
+		"production": {
+			"name": "backend",
+			"vars": {
+				"ENVIRONMENT": "production",
+				"FIREBASE_PROJECT_ID": "cloudflare-todo-sample",
+				"PUBLIC_JWK_CACHE_KEY": "firebase-jwk-cache"
+			}
+		}
+	}
+
+	/**
 	 * Static Assets
 	 * https://developers.cloudflare.com/workers/static-assets/binding/
 	 */

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -13,3 +13,7 @@ VITE_FIREBASE_APP_ID=1:123456789:web:abcdef123456
 # Development Only - Firebase Auth Emulator
 # Uncomment and set this for local development with Firebase Emulator
 # VITE_FIREBASE_AUTH_EMULATOR_URL=http://localhost:9099
+
+# API Base URL Configuration
+# Production: Replace with your actual Cloudflare Workers URL
+VITE_API_BASE_URL=https://backend.your-subdomain.workers.dev


### PR DESCRIPTION
## Summary
本番環境でのCORSエラーを修正するため、バックエンドデプロイとAPI URL設定を修正

## 問題
本番環境でフロントエンドが `localhost:8787` にアクセスしてCORSエラーが発生：
```
Access to fetch at 'http://localhost:8787/api/todos' from origin 'https://cloudflare-todo-sample-frontend.pages.dev' has been blocked by CORS policy
```

## 根本原因
1. `VITE_API_BASE_URL` 環境変数が未設定でローカル開発用URLを使用
2. バックエンドデプロイ設定に問題があり、正常にデプロイされていない可能性

## Changes

### 1. バックエンド設定修正
- `packages/backend/wrangler.jsonc`: production環境設定を追加
- デプロイコマンドを `--env production` に統一

### 2. デプロイワークフロー修正  
- `.github/workflows/deploy.yml`: フロントエンドがバックエンドデプロイ完了後に実行されるよう依存関係修正
- フロントエンドビルドに `VITE_API_BASE_URL` 環境変数を追加

### 3. 環境変数設定ファイル更新
- `.env.local`: 開発環境用API URL設定を追加
- `.env.example`: 本番環境用API URL設定例を追加

## Test plan
- [ ] バックエンドが正常にCloudflare Workersにデプロイされる
- [ ] フロントエンドが正しいWorkers URLにアクセスする
- [ ] 本番環境でCORSエラーが解消される
- [ ] ダッシュボードでTodo一覧が正常表示される

## Prerequisites
GitHub Secretsに `VITE_API_BASE_URL` が設定されている必要があります

## Related
Closes #24

🤖 Generated with [Claude Code](https://claude.ai/code)