### PR TITLE
fix: CSP修正 - バックエンドAPI接続許可（*.workers.dev追加）

### DIFF
--- a/packages/frontend/public/_headers
+++ b/packages/frontend/public/_headers
@@ -25,7 +25,7 @@
   # Content Security Policy (Phase A: 基本設定)
   # Firebase Authentication + React + TailwindCSS に対応
   # 段階的に厳格化予定（Phase B → Phase C）
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://*.googleapis.com https://*.firebase.com https://*.firebaseapp.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebase.com https://*.firebaseapp.com wss://*.firebase.com; img-src 'self' data: https:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://*.googleapis.com https://*.firebase.com https://*.firebaseapp.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebase.com https://*.firebaseapp.com wss://*.firebase.com https://*.workers.dev; img-src 'self' data: https:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
   
   # Cross-Origin制御
   Cross-Origin-Embedder-Policy: credentialless


### PR DESCRIPTION
## 📋 概要

Issue #43で報告されたCSPエラーを修正します。
セキュリティヘッダー実装により、バックエンドAPI（`*.workers.dev`）への接続がブロックされていた問題を解決します。

## 🚨 修正対象エラー

```javascript
Refused to connect to 'https://backend.toshiaki-mukai-9981.workers.dev/api/todos' 
because it violates the following Content Security Policy directive: 
"connect-src 'self' https://*.googleapis.com https://*.firebase.com https://*.firebaseapp.com wss://*.firebase.com"
```

### 影響
- ✅ Firebase認証: 正常動作
- ❌ ToDoAPI接続: CSPでブロック → **修正対象**
- ❌ ダッシュボード機能: 使用不可 → **修正対象**

## 🛠️ 修正内容

### CSP設定修正
**ファイル**: `packages/frontend/public/_headers`

#### 修正前
```
connect-src 'self' https://*.googleapis.com https://*.firebase.com https://*.firebaseapp.com wss://*.firebase.com
```

#### 修正後
```
connect-src 'self' https://*.googleapis.com https://*.firebase.com https://*.firebaseapp.com wss://*.firebase.com https://*.workers.dev
```

**変更点**: `https://*.workers.dev` を追加

## 🔐 セキュリティ考慮

### 許可するドメイン
- **`*.workers.dev`**: Cloudflare Workers公式ドメイン
- **必要性**: バックエンドAPI接続に必要不可欠
- **安全性**: Cloudflareが管理する信頼できるドメイン

### 継続する保護
- ✅ **XSS攻撃防止**: script-src制限継続
- ✅ **クリックジャッキング防止**: X-Frame-Options: DENY継続
- ✅ **不正ドメインブロック**: 許可リスト以外は拒否
- ✅ **その他セキュリティヘッダー**: 全て維持

## 🔗 関連

- **Issue**: #43（CSPバックエンドAPI接続エラー）
- **前回PR**: #40（セキュリティヘッダー実装）✅完了
- **前回PR**: #42（UTF-8エラー修正）✅完了

## 🧪 テスト計画

1. **デプロイ後確認**:
   - バックエンドAPI接続成功
   - ToDoアプリCRUD機能正常動作
   - Firebase認証継続動作

2. **セキュリティ確認**:
   - 不正ドメインへの接続は引き続きブロック
   - XSS・クリックジャッキング保護継続

## 🚀 期待される効果

### 機能面
- ✅ バックエンドAPI接続成功
- ✅ ToDoアプリ全機能正常化
- ✅ ダッシュボード完全動作

### セキュリティ面
- ✅ セキュリティ保護継続
- ✅ 必要最小限の許可追加
- ✅ Firebase + Backend API の安全な連携

🤖 Generated with [Claude Code](https://claude.ai/code)