### PR TITLE
fix: wrangler.jsonc production環境のbuild設定エラー修正

### DIFF
--- a/packages/backend/wrangler.jsonc
+++ b/packages/backend/wrangler.jsonc
@@ -70,12 +70,6 @@
 				"FIREBASE_PROJECT_ID": "cloudflare-todo-sample",
 				"PUBLIC_JWK_CACHE_KEY": "firebase-jwk-cache"
 			},
-			/** 本番環境でのビルド設定（セキュリティ強化） */
-			"build": {
-				"command": "npm run build",
-				"cwd": ".",
-				"watch_dir": "src"
-			},
 			"kv_namespaces": [
 				{
 					"binding": "JWT_CACHE",


### PR DESCRIPTION
## 概要

CDで発生している `npm run build` エラーを修正します。

## 問題

mainブランチマージ後のCD（Continuous Deployment）で以下エラーが発生:

```
[custom build] Running: npm run build
[custom build] npm error Missing script: "build"
✘ [ERROR] Error: Command failed with exit code 1: npm run build
```

## 原因

- `wrangler.jsonc` の production 環境設定で `"command": "npm run build"` が定義
- `package.json` には "build" スクリプトが存在しない
- Wrangler がデプロイ時に存在しないbuildコマンドを実行してエラー

## 解決策

`wrangler.jsonc` の production 環境から `build` ブロック（L74-78）を削除

**理由**:
- Wrangler 4.x は TypeScript を直接処理可能
- 事前のビルドステップは不要
- シンプルで保守性が高い

## テスト計画

- [ ] wrangler.jsonc から build 設定削除
- [ ] ローカルで `wrangler deploy --env production --dry-run` 実行
- [ ] CDパイプライン動作確認
- [ ] 本番環境デプロイ成功確認

## 影響範囲

- 本番環境デプロイプロセスのみ
- 既存の機能に影響なし
- 開発環境には影響なし

Closes #48

🤖 Generated with [Claude Code](https://claude.ai/code)